### PR TITLE
performance and more

### DIFF
--- a/demo/NtFreX.Audio.Console/(Demos)/DrawDiagramsDemo.cs
+++ b/demo/NtFreX.Audio.Console/(Demos)/DrawDiagramsDemo.cs
@@ -106,7 +106,7 @@ namespace NtFreX.Audio.Console
         private static string DrawSvg(Sample[][] data, string[] colors, float[] opacities, IAudioFormat format)
         {
             var width = data[0].Length;
-            var maxValue = data.SelectMany(x => x).Max(x => x.Value);
+            var maxValue = data.SelectMany(x => x).Max(x => x.AsNumber());
             var modifier = SvgHeight / (maxValue * 2f);
 
             var image = new StringBuilder();
@@ -149,7 +149,7 @@ namespace NtFreX.Audio.Console
             writer.WriteLine($"<path stroke=\"{color}\" stroke-width=\"1\" stroke-opacity=\"{opacity}\" fill-opacity=\"0\" d=\"M0 {SvgMiddle}");
             for (int i = 0; i < data.Length; i++)
             {
-                var value = data[i].Value * modifier;
+                var value = data[i].AsNumber() * modifier;
                 writer.WriteLine($"L{i} {SvgMiddle + value} ");
             }
             writer.WriteLine("\" />");
@@ -167,7 +167,7 @@ namespace NtFreX.Audio.Console
                 .ToInMemoryContainerAsync()
                 .ConfigureAwait(false);
 
-            var monoData = await monoAudio.SelectAsync(x => new Complex(x.Value, 0)).ToArrayAsync().ConfigureAwait(false);
+            var monoData = await monoAudio.SelectAsync(x => new Complex(x.AsNumber(), 0)).ToArrayAsync().ConfigureAwait(false);
             var steps = monoData.Length / stepSize;
             var data = new double[steps][];
             for (var col = 0; col < steps; col++)

--- a/demo/NtFreX.Audio.Console/NtFreX.Audio.Console.csproj
+++ b/demo/NtFreX.Audio.Console/NtFreX.Audio.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SolutionDir)'==''">

--- a/perf/NtFreX.Audio.Performance/AudioPipeBenchmark.cs
+++ b/perf/NtFreX.Audio.Performance/AudioPipeBenchmark.cs
@@ -11,9 +11,11 @@ using System.Threading.Tasks;
 namespace NtFreX.Audio.Performance
 {
     [SimpleJob(RuntimeMoniker.NetCoreApp31)]
-    [SimpleJob(RuntimeMoniker.NetCoreApp50)]
+    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
     [SimpleJob(RuntimeMoniker.CoreRt31)]
     [SimpleJob(RuntimeMoniker.CoreRt50)]
+    [SimpleJob(RuntimeMoniker.CoreRt60)]
     public class AudioPipeBenchmark
     {
         private IAudioFormat targetFormat = new AudioFormat(WellKnownSampleRate.Hz48000, 32, 2, AudioFormatType.Pcm);

--- a/perf/NtFreX.Audio.Performance/AudioPipeBenchmark.cs
+++ b/perf/NtFreX.Audio.Performance/AudioPipeBenchmark.cs
@@ -10,10 +10,8 @@ using System.Threading.Tasks;
 
 namespace NtFreX.Audio.Performance
 {
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [SimpleJob(RuntimeMoniker.Net50)]
     [SimpleJob(RuntimeMoniker.Net60)]
-    [SimpleJob(RuntimeMoniker.CoreRt31)]
     [SimpleJob(RuntimeMoniker.CoreRt50)]
     [SimpleJob(RuntimeMoniker.CoreRt60)]
     public class AudioPipeBenchmark

--- a/perf/NtFreX.Audio.Performance/NtFreX.Audio.Performance.csproj
+++ b/perf/NtFreX.Audio.Performance/NtFreX.Audio.Performance.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/perf/NtFreX.Audio.Performance/NtFreX.Audio.Performance.csproj
+++ b/perf/NtFreX.Audio.Performance/NtFreX.Audio.Performance.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SolutionDir)'==''">

--- a/perf/NtFreX.Audio.Performance/SampleRateAudioSamplerBenchmark.cs
+++ b/perf/NtFreX.Audio.Performance/SampleRateAudioSamplerBenchmark.cs
@@ -7,10 +7,8 @@ using System.Threading.Tasks;
 
 namespace NtFreX.Audio.Performance
 {
-    [SimpleJob(RuntimeMoniker.NetCoreApp31)]
     [SimpleJob(RuntimeMoniker.Net50)]
     [SimpleJob(RuntimeMoniker.Net60)]
-    [SimpleJob(RuntimeMoniker.CoreRt31)]
     [SimpleJob(RuntimeMoniker.CoreRt50)]
     [SimpleJob(RuntimeMoniker.CoreRt60)]
     public class SampleRateAudioSamplerBenchmark

--- a/perf/NtFreX.Audio.Performance/SampleRateAudioSamplerBenchmark.cs
+++ b/perf/NtFreX.Audio.Performance/SampleRateAudioSamplerBenchmark.cs
@@ -8,9 +8,11 @@ using System.Threading.Tasks;
 namespace NtFreX.Audio.Performance
 {
     [SimpleJob(RuntimeMoniker.NetCoreApp31)]
-    [SimpleJob(RuntimeMoniker.NetCoreApp50)]
+    [SimpleJob(RuntimeMoniker.Net50)]
+    [SimpleJob(RuntimeMoniker.Net60)]
     [SimpleJob(RuntimeMoniker.CoreRt31)]
     [SimpleJob(RuntimeMoniker.CoreRt50)]
+    [SimpleJob(RuntimeMoniker.CoreRt60)]
     public class SampleRateAudioSamplerBenchmark
     {
         [Benchmark]

--- a/src/NtFreX.Audio.AdapterInfrastructure/NtFreX.Audio.AdapterInfrastructure.csproj
+++ b/src/NtFreX.Audio.AdapterInfrastructure/NtFreX.Audio.AdapterInfrastructure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NtFreX.Audio.Infrastructure/Debug.cs
+++ b/src/NtFreX.Audio.Infrastructure/Debug.cs
@@ -7,14 +7,14 @@ namespace NtFreX.Audio.Infrastructure
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #pragma warning disable CA1801 // Review unused parameters
-        public static void Assert(bool condition, string message)
+        public static void Assert(bool condition, string errorMessage)
 #pragma warning restore CA1801 // Review unused parameters
         {
 #if DEBUG
             // fun fact: System.Debug.Assert is so slow it cannot be used here
             if (!condition)
             {
-                throw new Exception(message);
+                throw new Exception(errorMessage);
             }
 #endif
         }

--- a/src/NtFreX.Audio.Infrastructure/EndianAwareBitConverter.cs
+++ b/src/NtFreX.Audio.Infrastructure/EndianAwareBitConverter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Binary;
 using System.Linq;
 using System.Text;
 
@@ -6,6 +7,62 @@ namespace NtFreX.Audio.Infrastructure
 {
     public static class EndianAwareBitConverter
     {
+        public static void ToMemory(this float value, Span<byte> destination, bool isLittleEndian = true)
+        {
+            if (isLittleEndian)
+            {
+                BinaryPrimitives.WriteSingleLittleEndian(destination, value);
+            }
+            else
+            {
+                BinaryPrimitives.WriteSingleBigEndian(destination, value);
+            }
+        }
+        public static void ToMemory(this double value, Span<byte> destination, bool isLittleEndian = true)
+        {
+            if (isLittleEndian)
+            {
+                BinaryPrimitives.WriteDoubleLittleEndian(destination, value);
+            }
+            else
+            {
+                BinaryPrimitives.WriteDoubleBigEndian(destination, value);
+            }
+        }
+        public static void ToMemory(this short value, Span<byte> destination, bool isLittleEndian = true)
+        {
+            if (isLittleEndian)
+            {
+                BinaryPrimitives.WriteInt16LittleEndian(destination, value);
+            }
+            else
+            {
+                BinaryPrimitives.WriteInt16BigEndian(destination, value);
+            }
+        }
+        public static void ToMemory(this long value, Span<byte> destination, bool isLittleEndian = true)
+        {
+            if (isLittleEndian)
+            {
+                BinaryPrimitives.WriteInt64LittleEndian(destination, value);
+            }
+            else
+            {
+                BinaryPrimitives.WriteInt64BigEndian(destination, value);
+            }
+        }
+        public static void ToMemory(this int value, Span<byte> destination, bool isLittleEndian = true)
+        {
+            if (isLittleEndian)
+            {
+                BinaryPrimitives.WriteInt32LittleEndian(destination, value);
+            }
+            else
+            {
+                BinaryPrimitives.WriteInt32BigEndian(destination, value);
+            }
+        }
+
         public static Memory<byte> ToMemory(this float value, bool isLittleEndian = true)
         {
             var mem = BitConverter.GetBytes(value);

--- a/src/NtFreX.Audio.Infrastructure/FloatingPointNumber.cs
+++ b/src/NtFreX.Audio.Infrastructure/FloatingPointNumber.cs
@@ -30,5 +30,23 @@ namespace NtFreX.Audio.Infrastructure
                 _ => throw new ArgumentException($"Floating point numbers with {bits} bits are not supported.", nameof(bits)),
             };
         }
+
+        public static void ToRequiredBits(uint bits, Span<byte> buffer, double value = 0, bool isLittleEndian = true)
+        {
+            switch (bits)
+            {
+                case 16:
+                    ((short)(value * (short.MaxValue + 1f))).ToMemory(buffer, isLittleEndian);
+                    break;
+                case 32:
+                    ((float)value).ToMemory(buffer, isLittleEndian);
+                    break;
+                case 64:
+                    value.ToMemory(buffer, isLittleEndian);
+                    break;
+                default:
+                    throw new ArgumentException($"Floating point numbers with {bits} bits are not supported.", nameof(bits));
+            }
+        }
     }
 }

--- a/src/NtFreX.Audio.Infrastructure/Helpers/StreamFactory.cs
+++ b/src/NtFreX.Audio.Infrastructure/Helpers/StreamFactory.cs
@@ -2,6 +2,6 @@
 {
     internal static class StreamFactory
     {
-        public static int GetBufferSize() => 1024 * 8;
+        public static int GetBufferSize() => 1024 * 2;
     }
 }

--- a/src/NtFreX.Audio.Infrastructure/NtFreX.Audio.Infrastructure.csproj
+++ b/src/NtFreX.Audio.Infrastructure/NtFreX.Audio.Infrastructure.csproj
@@ -2,6 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/NtFreX.Audio.Infrastructure/Number.cs
+++ b/src/NtFreX.Audio.Infrastructure/Number.cs
@@ -30,5 +30,26 @@ namespace NtFreX.Audio.Infrastructure
                 _ => throw new ArgumentException($"Numbers with {bits} bits are not supported.", nameof(bits)),
             };
         }
+
+        public static void ToRequiredBits(uint bits, Span<byte> buffer, long value = 0, bool isLittleEndian = true)
+        {
+            switch (bits)
+            {
+                case 8:
+                    buffer[0] = (byte)value;
+                    break;
+                case 16:
+                    ((short)value).ToMemory(buffer, isLittleEndian);
+                    break;
+                case 32: 
+                    ((int)value).ToMemory(buffer, isLittleEndian);
+                    break;
+                case 64:
+                    value.ToMemory(buffer, isLittleEndian);
+                    break;
+                default:
+                    throw new ArgumentException($"Numbers with {bits} bits are not supported.", nameof(bits));
+            }
+        }
     }
 }

--- a/src/NtFreX.Audio.Infrastructure/NumberFactory.cs
+++ b/src/NtFreX.Audio.Infrastructure/NumberFactory.cs
@@ -11,6 +11,22 @@ namespace NtFreX.Audio.Infrastructure
                    throw new NotImplementedException("The given audio format type is not supported");
         }
 
+        public static void DeconstructNumber(SampleDefinition definition, double value, Span<byte> buffer)
+        {
+            if (definition.Type == AudioFormatType.Pcm)
+            {
+                Number.ToRequiredBits(definition.Bits, buffer, (long)value, definition.IsLittleEndian);
+            }
+            else if (definition.Type == AudioFormatType.IeeFloat)
+            {
+                FloatingPointNumber.ToRequiredBits(definition.Bits, buffer, value, definition.IsLittleEndian);
+            }
+            else
+            {
+                throw new NotImplementedException("The given audio format type is not supported");
+            }
+        }
+
         public static double ConstructNumber(AudioFormatType type, bool isLittleEndian, Memory<byte> value)
         {
             return type == AudioFormatType.Pcm ? Number.FromGivenBits(value, isLittleEndian) :

--- a/src/NtFreX.Audio.Infrastructure/Sample.cs
+++ b/src/NtFreX.Audio.Infrastructure/Sample.cs
@@ -7,44 +7,43 @@ namespace NtFreX.Audio.Infrastructure
 {
     public struct Sample : IEquatable<Sample>
     {
-        public double Value { get; }
-        //TODO: get rid of this?
         public SampleDefinition Definition { get; }
 
-        private Memory<byte>? cache;
+        private Memory<byte>? memory;
+        private double? number;
 
         public Sample(Memory<byte> value, SampleDefinition definition)
         {
             Definition = definition;
 
-            this.cache = value;
-            this.Value = NumberFactory.ConstructNumber(definition.Type, definition.IsLittleEndian, value);
+            this.memory = value;
+            this.number = null;
         }
 
         public Sample(double value, SampleDefinition definition)
         {
             Definition = definition;
 
-            this.cache = null;
-            this.Value = value;
+            this.number = value;
+            this.memory = null;
         }
 
         public static Sample Zero(SampleDefinition definition) => new Sample(0d, definition);
 
         public static Sample operator +(Sample a, Sample b)
-            => a.Definition == b.Definition ? new Sample(a.Value + b.Value, a.Definition) : throw new Exception();
+            => a.Definition == b.Definition ? new Sample(a.AsNumber() + b.AsNumber(), a.Definition) : throw new Exception();
         public static Sample operator -(Sample a, Sample b)
-            => a.Definition == b.Definition ? new Sample(a.Value - b.Value, a.Definition) : throw new Exception();
+            => a.Definition == b.Definition ? new Sample(a.AsNumber() - b.AsNumber(), a.Definition) : throw new Exception();
         public static Sample operator +(Sample a, double b)
-            => new Sample(a.Value + b, a.Definition);
+            => new Sample(a.AsNumber() + b, a.Definition);
         public static Sample operator -(Sample a, double b)
-            => new Sample(a.Value - b, a.Definition);
+            => new Sample(a.AsNumber() - b, a.Definition);
         public static Sample operator /(Sample a, double b)
-            => new Sample(a.Value / b, a.Definition);
+            => new Sample(a.AsNumber() / b, a.Definition);
         public static Sample operator *(Sample a, double b)
-            => new Sample(a.Value * b, a.Definition);
-        public static bool operator <(Sample a, Sample b) => a.Definition == b.Definition ? a.Value < b.Value : throw new Exception();
-        public static bool operator >(Sample a, Sample b) => a.Definition == b.Definition ? a.Value > b.Value : throw new Exception();
+            => new Sample(a.AsNumber() * b, a.Definition);
+        public static bool operator <(Sample a, Sample b) => a.Definition == b.Definition ? a.AsNumber() < b.AsNumber() : throw new Exception();
+        public static bool operator >(Sample a, Sample b) => a.Definition == b.Definition ? a.AsNumber() > b.AsNumber() : throw new Exception();
         public static bool operator ==(Sample left, Sample right) => left.Equals(right);
         public static bool operator !=(Sample left, Sample right) => !(left == right);
 
@@ -53,17 +52,28 @@ namespace NtFreX.Audio.Infrastructure
         public static Sample Divide(Sample left, double right) => left / right;
         public static Sample Multiply(Sample left, double right) => left * right;
 
-        public Memory<byte> AsByteArray()
+        public double AsNumber()
         {
-            if (cache == null)
+            if(number == null)
             {
-                cache = NumberFactory.DeconstructNumber(Definition, Value);
+                Debug.Assert(memory != null, "If the number is not provided memory must be");
+                number = NumberFactory.ConstructNumber(Definition.Type, Definition.IsLittleEndian, memory!.Value);
             }
 
-            return cache.Value;
+            return number.Value;
+        }
+        public Memory<byte> AsByteArray()
+        {
+            if (memory == null)
+            {
+                Debug.Assert(number != null, "If memory is not provided the number must be");
+                memory = NumberFactory.DeconstructNumber(Definition, number!.Value);
+            }
+
+            return memory.Value;
         }
 
-        public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
+        public override string ToString() => AsNumber().ToString(CultureInfo.InvariantCulture);
         public int CompareTo(Sample other) => this == other ? 0 : this < other ? 1 : -1;
         
         public override bool Equals(object? obj)

--- a/src/NtFreX.Audio.Infrastructure/SampleExtensions.cs
+++ b/src/NtFreX.Audio.Infrastructure/SampleExtensions.cs
@@ -37,7 +37,9 @@ namespace NtFreX.Audio.Infrastructure
                     throw new Exception("The enumeration cannot be empty");
                 }
 
-                return new Sample(average, definition!.Value);
+                var sample = new Sample(average, definition!.Value);
+                definition = null;
+                return sample;
             }
         }
 

--- a/src/NtFreX.Audio.Infrastructure/SampleExtensions.cs
+++ b/src/NtFreX.Audio.Infrastructure/SampleExtensions.cs
@@ -12,7 +12,7 @@ namespace NtFreX.Audio.Infrastructure
         public static Sample Average(this IEnumerable<Sample> samples)
         {
             var data = samples.ToArray();
-            var average = data.Average(sample => sample.Value);
+            var average = data.Average(sample => sample.AsNumber());
             return new Sample(average, data[0].Definition);
         }
 

--- a/src/NtFreX.Audio.Infrastructure/Threading/StreamEnumerator.cs
+++ b/src/NtFreX.Audio.Infrastructure/Threading/StreamEnumerator.cs
@@ -8,7 +8,7 @@ namespace NtFreX.Audio.Infrastructure.Threading
 {
     public sealed class StreamEnumerator : ISeekableAsyncEnumerator<Memory<byte>>
     {
-        private readonly byte[] buffer = new byte[StreamFactory.GetBufferSize()];
+        private readonly Memory<byte> buffer = new byte[StreamFactory.GetBufferSize()];
         private readonly ReadLockContext<Stream> readLockContext;
         private readonly long startIndex;
         private readonly long? endIndex;
@@ -45,7 +45,7 @@ namespace NtFreX.Audio.Infrastructure.Threading
             var realBufferSize = endIndex != null && readLockContext.Data.Position + bufferSize > endIndex
                 ? endIndex - readLockContext.Data.Position
                 : bufferSize;
-            var memory = buffer.AsMemory(0, (int) realBufferSize);
+            var memory = buffer.Slice(0, (int) realBufferSize);
 
             var size = await readLockContext.Data.ReadAsync(memory).ConfigureAwait(false);
             if(size == 0)

--- a/src/NtFreX.Audio/AudioEnvironment.cs
+++ b/src/NtFreX.Audio/AudioEnvironment.cs
@@ -12,11 +12,36 @@ namespace NtFreX.Audio
 {
     public static class AudioEnvironment
     {
+        private static IAudioPlatform? platform;
+        private static IAudioDeviceFactory? deviceFactory;
+
         public static AudioSamplerFactory Sampler { [return:NotNull] get; } = AudioSamplerFactory.Instance;
         public static AudioContainerSerializerFactory Serializer { [return:NotNull] get; } = AudioContainerSerializerFactory.Instance;
         public static AudioConverterFactory Converter { [return: NotNull] get; } = AudioConverterFactory.Instance;
-        public static IAudioPlatform Platform { [return:NotNull] get; } = AudioPlatformAdapterFactory.Instance.Get();
-        public static IAudioDeviceFactory DeviceFactory { [return: NotNull] get; } = Platform.AudioDeviceFactory;
+        public static IAudioPlatform Platform 
+        { 
+            // only initialize platform once it has been requested for the first time
+            get
+            {
+                if(platform == null)
+                {
+                    platform = AudioPlatformAdapterFactory.Instance.Get();
+                }
+                return platform;
+            }
+        }
+        public static IAudioDeviceFactory DeviceFactory
+        {
+            // only initialize platform once deviceFactory has been requested for the first time
+            get
+            {
+                if(deviceFactory == null)
+                {
+                    deviceFactory = Platform.AudioDeviceFactory;
+                }
+                return deviceFactory;
+            }
+        }
     }
 
     public static class AudioContainer

--- a/src/NtFreX.Audio/NtFreX.Audio.csproj
+++ b/src/NtFreX.Audio/NtFreX.Audio.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>    

--- a/src/NtFreX.Audio/Samplers/(Implementations)/BitsPerSampleAudioSampler.cs
+++ b/src/NtFreX.Audio/Samplers/(Implementations)/BitsPerSampleAudioSampler.cs
@@ -47,8 +47,8 @@ namespace NtFreX.Audio.Samplers
             return new Sample(
                 format.Type switch
                 {
-                    AudioFormatType.Pcm => isNewBigger ? sample.Value * factor : sample.Value / factor,
-                    AudioFormatType.IeeFloat => sample.Value,
+                    AudioFormatType.Pcm => isNewBigger ? sample.AsNumber() * factor : sample.AsNumber() / factor,
+                    AudioFormatType.IeeFloat => sample.AsNumber(),
                     _ => throw new Exception()
                 }, definition);
         }

--- a/src/NtFreX.Audio/Samplers/(Implementations)/FloatToPcmAudioSampler.cs
+++ b/src/NtFreX.Audio/Samplers/(Implementations)/FloatToPcmAudioSampler.cs
@@ -32,6 +32,6 @@ namespace NtFreX.Audio.Samplers
         }
 
         private static Sample FloatToPcm(Sample sample, double max, SampleDefinition definition)
-            => new Sample(sample.Value * max, definition);
+            => new Sample(sample.AsNumber() * max, definition);
     }
 }

--- a/src/NtFreX.Audio/Samplers/(Implementations)/PcmToFloatAudioSampler.cs
+++ b/src/NtFreX.Audio/Samplers/(Implementations)/PcmToFloatAudioSampler.cs
@@ -33,6 +33,6 @@ namespace NtFreX.Audio.Samplers
         }
 
         private static Sample PcmToFloat(Sample sample, double max, SampleDefinition definition)
-            => new Sample(sample.Value / max, definition);
+            => new Sample(sample.AsNumber() / max, definition);
     }
 }

--- a/src/NtFreX.Audio/Samplers/AudioSamplerPipe.cs
+++ b/src/NtFreX.Audio/Samplers/AudioSamplerPipe.cs
@@ -1,4 +1,5 @@
 ﻿using NtFreX.Audio.Containers;
+using NtFreX.Audio.Infrastructure.Container;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -17,6 +18,21 @@ namespace NtFreX.Audio.Samplers
             samplers.Add(sampler(AudioSamplerFactory.Instance));
             return this;
         }
+        public Task<IntermediateEnumerableAudioContainer> RunAsync(IIntermediateAudioContainer audio, CancellationToken cancellationToken = default)
+        {
+            _ = audio ?? throw new ArgumentNullException(nameof(audio));
+
+            if (audio is IntermediateEnumerableAudioContainer enumerable)
+            {
+                return RunAsync(enumerable, cancellationToken);
+            }
+            else if (audio is IntermediateListAudioContainer list)
+            {
+                return RunAsync(list, cancellationToken);
+            }
+            throw new Exception("Unknown intermediate container type was given");
+        }
+
         public Task<IntermediateEnumerableAudioContainer> RunAsync(IntermediateListAudioContainer audio, CancellationToken cancellationToken = default)
         {
             _ = audio ?? throw new ArgumentNullException(nameof(audio));

--- a/src/adapters/NtFreX.Audio.Alsa/NtFreX.Audio.Alsa.csproj
+++ b/src/adapters/NtFreX.Audio.Alsa/NtFreX.Audio.Alsa.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
   </PropertyGroup>
 

--- a/src/adapters/NtFreX.Audio.PulseAudio/NtFreX.Audio.PulseAudio.csproj
+++ b/src/adapters/NtFreX.Audio.PulseAudio/NtFreX.Audio.PulseAudio.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/adapters/NtFreX.Audio.Wasapi/NtFreX.Audio.Wasapi.csproj
+++ b/src/adapters/NtFreX.Audio.Wasapi/NtFreX.Audio.Wasapi.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/NtFreX.Audio.Tests/NtFreX.Audio.Tests.csproj
+++ b/test/NtFreX.Audio.Tests/NtFreX.Audio.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
- only initialize platform once it has been requested for the first time;
- setup dotnet6 benchmark and fix usage;
- only construct number for sample from memory when needed;
- allocation free wasapi message pump;
- allocation free number factory;
- memory pool for sample destruction;
- single threaded allocation free sample average algo;